### PR TITLE
added audit history for alias creation

### DIFF
--- a/repo/MemberRepo.php
+++ b/repo/MemberRepo.php
@@ -202,6 +202,33 @@ class MemberRepository {
 		$stmt->execute([$memberId, $associatedMemberId]);
 	}
 	
+	public function createAliasAuditTrail($associatedMemberId) {
+		$this->createAliasAuditTrailPax($associatedMemberId);
+		$this->createAliasAuditTrailQ($associatedMemberId);
+	}
+
+	public function createAliasAuditTrailPax($associatedMemberId) {
+		$stmt = $this->db->prepare('
+			insert into MEMBER_ALIAS_AUDIT (OLD_MEMBER_ID, OLD_F3_NAME, WORKOUT_ID, MEMBER_TYPE)
+				select m.MEMBER_ID, m.F3_NAME, wp.WORKOUT_ID, ? from WORKOUT_PAX wp
+					join MEMBER m on wp.MEMBER_ID = m.MEMBER_ID
+							where wp.MEMBER_ID=?;        
+		');
+
+		$stmt->execute(['PAX', $associatedMemberId]);
+	}
+
+	public function createAliasAuditTrailQ($associatedMemberId) {
+		$stmt = $this->db->prepare('
+			insert into MEMBER_ALIAS_AUDIT (OLD_MEMBER_ID, OLD_F3_NAME, WORKOUT_ID, MEMBER_TYPE)
+				select m.MEMBER_ID, m.F3_NAME, wq.WORKOUT_ID, ? from WORKOUT_Q wq
+					join MEMBER m on wq.MEMBER_ID = m.MEMBER_ID
+							where wq.MEMBER_ID=?;        
+		');
+
+		$stmt->execute(['Q', $associatedMemberId]);
+	}
+
 	public function relinkWorkoutPax($memberId, $associatedMemberId) {
 		$stmt = $this->db->prepare('
 			update WORKOUT_PAX

--- a/service/MemberService.php
+++ b/service/MemberService.php
@@ -97,6 +97,9 @@ class MemberService {
 		try {
 			$db->beginTransaction();
 			
+			// create an audit trail with the previous entries, in case we need to revert
+			$this->memberRepo->createAliasAuditTrail($associatedMemberId);
+
 			// create the alias if it doesn't already exist
 			if (!$this->memberRepo->findExistingAlias($memberId, $associatedMemberId)) {
 				$this->memberRepo->createAlias($memberId, $associatedMemberId);


### PR DESCRIPTION
Added support for creating an audit trail when an alias is created through the admin screen.  Audit records are added for both Q and PAX records so that the user could be recreated if needed.  Haven't needed it yet, but could!